### PR TITLE
Call the debugging hooks in BUILD instead of overriding sub new

### DIFF
--- a/lib/WebService/Shutterstock/Client.pm
+++ b/lib/WebService/Shutterstock/Client.pm
@@ -111,13 +111,12 @@ sub process_response {
 	}
 }
 
-sub new {
-	my $self = shift->SUPER::new(@_);
+sub BUILD {
+	my $self = shift;
 	if($ENV{SS_API_DEBUG}){
 		$self->getUseragent->add_handler("request_send",  sub { shift->dump(prefix => '> '); return });
 		$self->getUseragent->add_handler("response_done", sub { shift->dump(prefix => '< '); return });
 	}
-	return $self;
 }
 
 1;


### PR DESCRIPTION
Moo/Moose really don't want you to define your own constructor, and
this breaks with an upcoming version of Moo. Do the right thing to
avoid trouble.
