### PR TITLE
declare all attributes before modifying constructor

### DIFF
--- a/lib/WebService/Shutterstock/Lightbox.pm
+++ b/lib/WebService/Shutterstock/Lightbox.pm
@@ -11,17 +11,6 @@ use WebService::Shutterstock::DeferredData qw(deferred);
 use WebService::Shutterstock::AuthedClient;
 with 'WebService::Shutterstock::AuthedClient';
 
-deferred(
-	['lightbox_name' => 'name', 'rw'],
-	['images' => '_images', 'ro'],
-	sub {
-		my $self = shift;
-		my $client = $self->client;
-		$client->GET( sprintf('/lightboxes/%s/extended.json', $self->id), $self->with_auth_params );
-		return $client->process_response;
-	}
-);
-
 =attr id
 
 The ID of this lightbox
@@ -38,6 +27,17 @@ Returns a URL for access this lightbox without authenticating.
 
 has id => ( is => 'rw', init_arg => 'lightbox_id' );
 has public_url => ( is => 'lazy' );
+
+deferred(
+	['lightbox_name' => 'name', 'rw'],
+	['images' => '_images', 'ro'],
+	sub {
+		my $self = shift;
+		my $client = $self->client;
+		$client->GET( sprintf('/lightboxes/%s/extended.json', $self->id), $self->with_auth_params );
+		return $client->process_response;
+	}
+);
 
 sub _build_public_url {
 	my $self = shift;


### PR DESCRIPTION
Moo does not generally support wrapping its constructor, but it will
work in some cases.  Future versions of Moo will detect the problematic
cases, such as attributes being defined after the constructor has been
replaced.  Avoid this by declaring the attributes first.

In general, the deferred mechanism seems odd.  It seems to be wrapping the constructor to apply defaults, but that could just as easily be done by applying actual defaults to the attributes.  If the attributes need to be initialized on object creation but after other attributes, that can be done by making them lazy and calling their accessors in a BUILD sub.  That would be a better supported mechanism, and should still be possible to set up using a `deferred()` call like this code uses if that was desired.